### PR TITLE
Add var percona_server_enable_handler_restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Set up a [percona-server](https://www.percona.com/software/mysql-database/percon
 
 * `percona_server_toolkit_udfs_manage`: [default: `true`]: Whether or not to install recommended hash functions ([see](https://www.percona.com/doc/percona-server/LATEST/management/udf_percona_toolkit.html))
 
+##### Restart after configuration change
+
+* `percona_server_enable_handler_restart`: [default: `true`]: Whether or not to restart mysql service after a configuration change, useful for production environments
+
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,4 @@ percona_server_zoneinfo_tz_name: ''
 percona_server_zoneinfo_command: "mysql_tzinfo_to_sql {{ percona_server_zoneinfo_tz_dir }}"
 
 percona_server_toolkit_udfs_manage: true
+percona_server_enable_handler_restart: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart percona-server
   service:
     name: mysql
-    state: restarted
-  when: service_default_state | default('started') == 'started'
+    state: "{{ percona_restart_handler_state }}"
+  when: percona_server_enable_handler_restart and service_default_state | default('started' == 'started')


### PR DESCRIPTION
Useful for production environments when restart is not required to change some vars (i.e. max_connections).