### PR TITLE
Remove with_items in dirmngr dependency to avoid deprecation warning

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -2,12 +2,10 @@
 ---
 - name: repository | install | dependencies
   apt:
-    name: "{{ item }}"
+    name: dirmngr
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items:
-    - dirmngr
   when: ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '>=')
   tags:
     - percona-server-repository-install


### PR DESCRIPTION
There is only one dependency package name, so `with_items` is not necessary, and it otherwise causes the following deprecation warning:

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, 
please use `name: ['dirmngr']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```