### PR TITLE
Keep user passwords out of ansible log

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,7 @@
 # tasks file
 ---
 - name: install | configure debconf
+  no_log: true
   ansible.builtin.debconf:
     name: "{{ item.name }}"
     question: "{{ item.question }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,6 +7,7 @@
     priv: "{{ item[0].privs | join('/') }}"
     host: "{{ item[1] }}"
     state: present
+    no_log: true
   with_nested:
     - "{{ percona_server_users_present | selectattr('hosts', 'undefined') | list }}"
     - "{{ percona_server_users_present_hosts }}"
@@ -21,6 +22,7 @@
     priv: "{{ item[0].privs | join('/') }}"
     host: "{{ item[1] }}"
     state: present
+    no_log: true
   with_subelements:
     - "{{ percona_server_users_present | selectattr('hosts', 'defined') | list }}"
     - hosts


### PR DESCRIPTION
When creating users, their password is exposed in the ansible logs. This patch fixes at least some of the places where this happens (all of the places I saw when using the role)