### PR TITLE
Use explicit credentials if password-less access is not possible

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 ---
 percona_server_version: 5.7
 
+percona_server_root_username: root
 percona_server_root_password: '+eswuw9uthUteFreyAqu'
 
 percona_server_use_legacy_auth_method: false
@@ -15,7 +16,7 @@ percona_server_user_root_cnf_preset:
       - name: host
         value: localhost
       - name: user
-        value: root
+        value: "{{ percona_server_root_username }}"
       - name: password
         value: "'{{ percona_server_root_password }}'"
 percona_server_user_root_cnf: "{{ percona_server_user_root_cnf_preset }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -6,6 +6,9 @@
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_items: "{{ percona_server_databases_present }}"
   tags:
     - percona-server-databases-create
@@ -14,6 +17,9 @@
   community.mysql.mysql_db:
     name: "{{ item.name }}"
     state: absent
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_items: "{{ percona_server_databases_absent }}"
   tags:
     - percona-server-databases-drop

--- a/tasks/ib-logfile.yml
+++ b/tasks/ib-logfile.yml
@@ -3,6 +3,8 @@
 - name: ib logfile | get datadir
   community.mysql.mysql_variables:
     variable: datadir
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   register: _datadir_value
   tags:
     - percona-server-store-datadir
@@ -23,6 +25,8 @@
       community.mysql.mysql_variables:
         variable: innodb_fast_shutdown
         value: "1"
+        login_user: "{{ percona_server_root_username }}"
+        login_password: "{{ percona_server_root_password }}"
       tags:
         - percona-server-ib-logfile-innodb-fast-shutdown
         - percona-server-ib-logfile-innodb-fast-shutdown-set

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,6 +8,9 @@
     host: "{{ item[1] }}"
     state: present
     no_log: true
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_nested:
     - "{{ percona_server_users_present | selectattr('hosts', 'undefined') | list }}"
     - "{{ percona_server_users_present_hosts }}"
@@ -23,6 +26,9 @@
     host: "{{ item[1] }}"
     state: present
     no_log: true
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_subelements:
     - "{{ percona_server_users_present | selectattr('hosts', 'defined') | list }}"
     - hosts
@@ -35,6 +41,9 @@
     name: "{{ item[0].name }}"
     host: "{{ item[1] }}"
     state: absent
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_nested:
     - "{{ percona_server_users_absent | selectattr('hosts', 'undefined') | list }}"
     - "{{ percona_server_users_absent_hosts }}"
@@ -47,6 +56,9 @@
     name: "{{ item[0].name }}"
     host: "{{ item[1] }}"
     state: absent
+    check_implicit_admin: true
+    login_user: "{{ percona_server_root_username }}"
+    login_password: "{{ percona_server_root_password }}"
   with_subelements:
     - "{{ percona_server_users_absent | selectattr('hosts', 'defined') | list }}"
     - hosts


### PR DESCRIPTION
When we disable the management of `/root/.my.cnf` with `percona_server_user_root_cnf_manage: false` we lose the ability to run ansible tasks in our playbook.  

Adding login_user and login_password let's us use the root password to run the tasks. 
check_implicit_admin makes sure to first attempt the password-less login if possible.

