### PR TITLE
Depend on debconf-utils, which provides the debconf-get-selections executable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,6 +55,7 @@ percona_server_debconf_selections:
 percona_server_dependencies_pre:
   - software-properties-common
   - dirmngr
+  - debconf-utils
 
 percona_server_dependencies:
   - "percona-server-client{{ percona_server_version_deb }}"


### PR DESCRIPTION
All of the `ansible.builtin.debconf` steps in tasks/install.yml failed for me on Debian Bullseye, because it calls the `debconf-get-selections` executable, which was not found.

I needed to install `debconf-utils` to add that executable, then everything worked.