### PR TITLE
Add tls_requires support for create of MySQL users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ None
         privs:
           - 'ipsum.*:ALL'
           - 'dolor.*:ALL'
+        tls_requires:
+          subject: '/CN=alice/O=MyDom, Inc./C=US/ST=Oregon/L=Portland'
+          cipher: 'ECDHE-ECDSA-AES256-SHA384'
       - name: adipiscing
         password: 'lacus'
         privs:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -25,6 +25,7 @@
     password: "{{ item[0].password }}"
     priv: "{{ item[0].privs | join('/') }}"
     host: "{{ item[1] }}"
+    tls_requires: "{{ item[0].tls_requires | default({}) }}"
     state: present
     check_implicit_admin: true
     login_user: "{{ percona_server_root_username }}"


### PR DESCRIPTION
Hello,

This pull request adds tls_requires for user management, according the documentation: https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-tls_requires