### PR TITLE
add percona 8.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Set up a [percona-server](https://www.percona.com/software/mysql-database/percon
 
 ##### General
 
-* `percona_server_version`: [default: `5.7`]: Version to install (e.g. `5.6`)
+* `percona_server_version`: [default: `5.7`]: Version to install (e.g. `5.6`, `8.0`, `8.4`)
 * `percona_server_root_username`: [default: `root`]: Root username
 * `percona_server_root_password`: [default: `+eswuw9uthUteFreyAqu`]: Root password **Make sure to change!**
 
@@ -30,7 +30,8 @@ Set up a [percona-server](https://www.percona.com/software/mysql-database/percon
 
 * `percona_server_user_root_cnf_manage`: [default: `true`]: Whether or not to manage `~root/.my.cnf`
 * `percona_server_user_root_cnf`: [default: `percona_server_user_root_cnf_preset`, see `defaults/main.yml`]: Root user configuration declarations
-* `percona_server_use_legacy_auth_method`: [default: `false`]: Use legacy authentication method **_(only Percona Server 8.0)_**
+* `percona_server_use_legacy_auth_method`: [default: `false`]: Use legacy authentication method **_(only Percona Server 8.0/8.4)_**. Note that Percona Server 8.4 has legacy authentication disabled by default.
+* `percona_server_telemetry_enabled`: [default: `false`]: Enable telemetry data collection **_(only Percona Server 8.4)_**. The telemetry agent is always installed but disabled by default.
 
 ##### SSL
 
@@ -65,7 +66,9 @@ Set up a [percona-server](https://www.percona.com/software/mysql-database/percon
 
 * `percona_server_users_present`: [default: `[]`]: Users to `CREATE`
 * `percona_server_users_present.{n}.name`: [required]: The name of the user
-* `percona_server_users_present.{n}.password`: [required]: The password of the user
+* `percona_server_users_present.{n}.password`: [required for legacy auth]: The password of the user
+* `percona_server_users_present.{n}.plugin`: [optional]: Authentication plugin to use (e.g. `caching_sha2_password`) **_(for Percona Server 8.0/8.4 without legacy auth)_**
+* `percona_server_users_present.{n}.plugin_auth_string`: [optional]: Authentication string for the plugin **_(for Percona Server 8.0/8.4 without legacy auth)_**
 * `percona_server_users_present.{n}.privs`: [required]: Privileges (e.g. `'test.*:ALL'`)
 * `percona_server_users_present.{n}.hosts`: [optional, default: `percona_server_users_present_hosts`]: Hosts to `CREATE` privileges for (e.g. `%`)
 
@@ -93,7 +96,7 @@ Set up a [percona-server](https://www.percona.com/software/mysql-database/percon
 
 ##### Toolkit UDFs
 
-* `percona_server_toolkit_udfs_manage`: [default: `true`]: Whether or not to install recommended hash functions ([see](https://www.percona.com/doc/percona-server/LATEST/management/udf_percona_toolkit.html))
+* `percona_server_toolkit_udfs_manage`: [default: `true`]: Whether or not to install recommended hash functions ([see](https://www.percona.com/doc/percona-server/LATEST/management/udf_percona_toolkit.html)). Note: This feature is automatically disabled for Percona Server 8.4 regardless of this setting.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,3 +59,6 @@ percona_server_zoneinfo_tz_name: ''
 percona_server_zoneinfo_command: "mysql_tzinfo_to_sql {{ percona_server_zoneinfo_tz_dir }}"
 
 percona_server_toolkit_udfs_manage: true
+
+# Telemetry settings for Percona Server 8.4
+percona_server_telemetry_enabled: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
   tags:
     - percona-server-install-configure-debconf
 
-- name: install | configure debconf for version 8.0/8.4 (Use Legacy Authentication Method)
+- name: install | configure debconf for version 8.0 (Use Legacy Authentication Method)
   ansible.builtin.debconf:
     name: 'percona-server-server'
     question: 'percona-server-server/default-auth-override'
@@ -20,7 +20,7 @@
     vtype: select
   changed_when: false
   when:
-    - percona_server_version is version('8.0', '==') or percona_server_version is version('8.4', '==')
+    - percona_server_version is version('8.0', '==')
     - percona_server_use_legacy_auth_method | bool
   tags:
     - percona-server-install-configure-debconf

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
   tags:
     - percona-server-install-configure-debconf
 
-- name: install | configure debconf for version 8.0 (Use Legacy Authentication Method)
+- name: install | configure debconf for version 8.0/8.4 (Use Legacy Authentication Method)
   ansible.builtin.debconf:
     name: 'percona-server-server'
     question: 'percona-server-server/default-auth-override'
@@ -20,10 +20,21 @@
     vtype: select
   changed_when: false
   when:
-    - percona_server_version is version('8.0', '==')
+    - percona_server_version is version('8.0', '==') or percona_server_version is version('8.4', '==')
     - percona_server_use_legacy_auth_method | bool
   tags:
     - percona-server-install-configure-debconf
+
+- name: install | telemetry package for Percona Server 8.4
+  ansible.builtin.apt:
+    name: "percona-telemetry-agent"
+    state: "{{ apt_install_state | default('latest') }}"
+  environment:
+    PERCONA_DISABLE_TELEMETRY: "{{ '1' if not percona_server_telemetry_enabled | bool else '0' }}"
+  when:
+    - percona_server_version is version('8.4', '==')
+  tags:
+    - percona-server-install-telemetry
 
 - name: install | dependencies
   ansible.builtin.apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,9 @@
     - configuration
     - percona-server
     - percona-server-toolkit-udfs
-  when: percona_server_toolkit_udfs_manage | bool
+  when:
+    - percona_server_toolkit_udfs_manage | bool
+    - percona_server_version is not version('8.4', '==')
 
 - name: zoneinfo
   ansible.builtin.import_tasks: zoneinfo.yml

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,9 +4,11 @@
   no_log: true
   community.mysql.mysql_user:
     name: "{{ item[0].name }}"
-    password: "{{ item[0].password }}"
+    password: "{{ item[0].password | default(omit) }}"
     priv: "{{ item[0].privs | join('/') }}"
     host: "{{ item[1] }}"
+    plugin: "{{ item[0].plugin | default(omit) }}"
+    plugin_auth_string: "{{ item[0].plugin_auth_string | default(omit) }}"
     state: present
     check_implicit_admin: true
     login_user: "{{ percona_server_root_username }}"
@@ -22,9 +24,11 @@
   no_log: true
   community.mysql.mysql_user:
     name: "{{ item[0].name }}"
-    password: "{{ item[0].password }}"
+    password: "{{ item[0].password | default(omit) }}"
     priv: "{{ item[0].privs | join('/') }}"
     host: "{{ item[1] }}"
+    plugin: "{{ item[0].plugin | default(omit) }}"
+    plugin_auth_string: "{{ item[0].plugin_auth_string | default(omit) }}"
     state: present
     check_implicit_admin: true
     login_user: "{{ percona_server_root_username }}"

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -20,7 +20,12 @@
 !includedir {{ percona_server_etc_my_cnf_includedir }}
 {% endif %}
 
-{% if percona_server_version is version('8.0', '==') and percona_server_use_legacy_auth_method | bool %}
+{% if percona_server_use_legacy_auth_method | bool %}
 [mysqld]
+{% if percona_server_version is version('8.4', '==') %}
+mysql_native_password = ON
+{% endif %}
+{% if percona_server_version is version('8.0', '==') %}
 default-authentication-plugin = mysql_native_password
+{% endif %}
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,9 +5,10 @@ percona_server_versions_supported:
   - '5.6'
   - '5.7'
   - '8.0'
+  - '8.4'
 
 percona_server_version_deb_prefix: "-{{ percona_server_version }}"
-percona_server_version_deb: "{{ '' if percona_server_version is version('8.0', '==') else percona_server_version_deb_prefix }}"
+percona_server_version_deb: "{{ '' if percona_server_version is version('8.0', '==') or percona_server_version is version('8.4', '==') else percona_server_version_deb_prefix }}"
 
 percona_server_repositories_5:
   - type: deb
@@ -31,7 +32,27 @@ percona_server_repositories_8:
     url: "http://repo.percona.com/tools/apt {{ ansible_distribution_release }}"
     component: main
 
-percona_server_repositories: "{{ percona_server_repositories_8 if percona_server_version is version('8.0', '==') else percona_server_repositories_5 }}"
+percona_server_repositories_84:
+  - type: deb
+    url: "http://repo.percona.com/ps-84-lts/apt {{ ansible_distribution_release }}"
+    component: main
+  - type: deb-src
+    url: "http://repo.percona.com/ps-84-lts/apt {{ ansible_distribution_release }}"
+    component: main
+  - type: deb
+    url: "http://repo.percona.com/tools/apt {{ ansible_distribution_release }}"
+    component: main
+  - type: deb-src
+    url: "http://repo.percona.com/tools/apt {{ ansible_distribution_release }}"
+    component: main
+  - type: deb
+    url: "http://repo.percona.com/telemetry/apt {{ ansible_distribution_release }}"
+    component: main
+  - type: deb-src
+    url: "http://repo.percona.com/telemetry/apt {{ ansible_distribution_release }}"
+    component: main
+
+percona_server_repositories: "{{ percona_server_repositories_84 if percona_server_version is version('8.4', '==') else percona_server_repositories_8 if percona_server_version is version('8.0', '==') else percona_server_repositories_5 }}"
 
 percona_server_debconf_selections:
   - name: "percona-server-server{{ percona_server_version_deb }}"
@@ -94,3 +115,4 @@ percona_server_libmysqlclient_map:
   5.6: libperconaserverclient18.1
   5.7: libperconaserverclient20
   8.0: libperconaserverclient21
+  8.4: libperconaserverclient22


### PR DESCRIPTION
- add percona 8.4 compatibility
- percona 8.4 apt package needs the telemetry agent installed (you can decide weather or not you want to send metrics via a new variable)
- disable toolkit-udfs for 8.4 since the plugin *.so files are not installed by the 8.4 package (checked it with dpkg)
- enable compatibility with new auth plugins via mysql.community role
- handle legacy auth via my.cnf (since plugin is disabled per default in 8.4)
- tested via vagrant on ubuntu24.04